### PR TITLE
Added shouldIgnorePath() to the callback function of the Filter iterator

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -23,8 +23,11 @@ final class Filter extends FilterIterator
         $re = new ReflectionMethod($filter, 'shouldProcessFile');
         $re->setAccessible(true);
 
-        $this->callback = function () use ($it, $filter, $re) {
-            return $re->invoke($filter, $it->current());
+        $pa = new ReflectionMethod($filter, 'shouldIgnorePath');
+        $pa->setAccessible(true);
+
+        $this->callback = function () use ($it, $filter, $re, $pa) {
+            return $re->invoke($filter, $it->current()) && !$pa->invoke($filter, $it->current());
         };
     }
 

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -52,7 +52,7 @@ final class Iterator implements \IteratorAggregate
             new RecursiveArrayIterator(
                 new EmptyIterator()
             ),
-            '',
+            "\0", // invalid path, just so shouldIgnorePath() doesn't complain that it doesn't have a value for $this->basedir
             $this->config,
             $this->ruleSet
         ));


### PR DESCRIPTION
This was my fix for the fact that any exclude-pattern from a phpcs XML ruleset wasn't being taken into account by diff-sniffer-core.