### PR TITLE
Trying to fix AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,8 @@ init:
   - SET PATH=C:\Program Files\OpenSSL;C:\tools\php72;%PATH%
 
 install:
+  - sc config wuauserv start=auto
+  - net start wuauserv
   - ps: IF (!(Test-Path 'C:\tools\php72')) {cinst -y --no-progress php}
   - ps: IF (!(Test-Path 'C:\Program Files\OpenSSL')) {cinst -y --no-progress OpenSSL.Light}
   - cd C:\tools\php72


### PR DESCRIPTION
The [builds](https://ci.appveyor.com/project/morozov/diff-sniffer-core/build/1.0.18/job/x19ets87m3hs26ni) are constantly failing with:
> Installing KB3035131...
WARNING: Update KB3035131 installation failed (exit code 1058).
WARNING: More details may be found in the installation log (C:\Users\appveyor\AppData\Local\Temp\1\chocolatey\KB3035131.Install.evt) or the system CBS log (C:\windows\Logs\CBS\CBS.log).
ERROR: Update KB3035131 installation failed (exit code 1058).
The install of kb3035131 was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\KB3035131\Tools\ChocolateyInstall.ps1'.
